### PR TITLE
Fixed prototype

### DIFF
--- a/gasm80.c
+++ b/gasm80.c
@@ -515,7 +515,7 @@ char *regs[] = {
     "M",
 };
 
-void message();
+void message(int error, char *message);
 char *match_register(char *, int, int *);
 char *match_expression(char *, int *);
 char *match_expression_level1(char *, int *);


### PR DESCRIPTION
...
gasm80.c:518:6: warning: a function declaration without a prototype is deprecated in all versions of C and is treated as a zero-parameter prototype in C2x, conflicting with a subsequent definition [-Wdeprecated-non-prototype]
  518 | void message();
      |      ^
gasm80.c:1458:6: note: conflicting prototype is here
 1458 | void message(int error, char *message)
      |      ^
9 warnings generated.
